### PR TITLE
Add transaction fee data to post return result

### DIFF
--- a/lib/Api.js
+++ b/lib/Api.js
@@ -378,6 +378,11 @@ class Api {
     let tr = new TransactionBuilder();
     tr.add_type_operation('post', op_data);
     await tr.set_required_fees(poster, false, true);
+
+    let tr_obj = tr.toObject();
+    let fee = (tr_obj.operations[0][1]).fee;
+    op_data.fee = fee;
+
     tr.add_signer(PrivateKey.fromWif(config.secondary_key));
 
     let common_return = await this.__broadCast(tr);


### PR DESCRIPTION
Transaction fee is needed, when the integrated platform needs to log csaf changes after post an article. 
Current return result only contains block number and transaction id, which can be used to retrieve fee info. However, the actual block that includes the transaction is usually after the returned block. So basically the fee info can not be instantly retrieved. In most cases, there are 3-6 seconds delay.